### PR TITLE
Fix context obj getting lost on action's this object

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -33,9 +33,8 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
           moduleAccessor.context = context
           actionPayload = await actionFunction.call(moduleAccessor, payload)
         } else {
-          ;(context.state as any).context = context
-          actionPayload = await actionFunction.call(context.state, payload)
-          delete (context.state as any).context
+          const thisObj = { context, ...(context.state as any) }
+          actionPayload = await actionFunction.call(thisObj, payload)
         }
         if (commit) {
           context.commit(commit, actionPayload)

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -37,9 +37,8 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
           rootState: any,
           rootGetters: GetterTree<any, any>
         ) {
-          ;(state as any).context = { getters, rootState, rootGetters }
-          const got = (descriptor.get as Function).call(state)
-          delete (state as any).context
+          const thisObj = { context: { getters, rootState, rootGetters }, ...(state as any) }
+          const got = (descriptor.get as Function).call(thisObj)
           return got
         }
       }

--- a/test/getters.ts
+++ b/test/getters.ts
@@ -13,6 +13,17 @@ class MyModule extends VuexModule {
     this.wheels += extra
   }
 
+  @Action({ rawError: true })
+  async incrWheelsAction(payload: number) {
+    const context = this.context
+    this.context.commit('incrWheels', payload)
+    const axles = this.context.getters.axles
+    // Notice that the getter just changed the action's this.context and then
+    // deleted it. Because this is actually state and context was added on to state by
+    // the action and then we did a get which then changed the context and then deleted it
+    expect(this.context).to.equal(context)
+  }
+
   get axles() {
     return this.wheels / 2
   }
@@ -26,8 +37,13 @@ const store = new Vuex.Store({
 })
 
 describe('fetching via getters works', () => {
+  it('should not override the context in the action', async () => {
+    await store.dispatch('incrWheelsAction', 2)
+    const axles = store.getters.axles
+    expect(axles).to.equal(2)
+  })
   it('should increase axles', function() {
-    store.commit('incrWheels', 4)
+    store.commit('incrWheels', 2)
     const axles = store.getters.axles
     expect(axles).to.equal(3)
   })

--- a/test/muation_and_action.ts
+++ b/test/muation_and_action.ts
@@ -22,6 +22,18 @@ class MyModule extends VuexModule {
   fetchCountDelta() {
     this.context.commit('incrCount', 5)
   }
+
+  @Action({ rawError: true })
+  async incrCountAction(payload) {
+    const context = this.context
+    await this.context.dispatch('getCountDelta')
+
+    // Notice that the action we just called just deleted this action's this.context.
+    // Because `this` is actually the vuex state and `context` was added on to `state` by
+    // the action and then we called another action which then added the context and then deleted it
+    // and now at this point this.context no longer exists
+    expect(this.context).to.equal(context)
+  }
 }
 
 const store = new Vuex.Store({
@@ -38,5 +50,12 @@ describe('dispatching action which mutates works', () => {
   it('should update count (sync)', async function() {
     store.dispatch('fetchCountDelta')
     expect(parseInt(store.state.mm.count)).to.equal(10)
+  })
+})
+
+describe('dispatching action which dipatches actions', () => {
+  it(`should not remove the context off the first action's this`, async function() {
+    await store.dispatch('incrCountAction')
+    expect(parseInt(store.state.mm.count)).to.equal(15)
   })
 })


### PR DESCRIPTION
Because the object `context` is being put onto the `state` object on getters and on actions, if you are in an action and you call another action and wait for it to finish that action will remove `context` off the state object when it's done leaving the first action to continue and suddenly this.context is gone.

Same thing happens if in an action you call a getter. Because the getter modifies state.context and also then deletes state.context, if you are in an action and you call a getter you will continue the rest of the action's function with context no longer being on `this`

This pull request fixes these issues