### PR TITLE
#36 Actions should return the value through vuex

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -37,6 +37,7 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
         if (commit) {
           context.commit(commit, actionPayload)
         }
+        return actionPayload
       } catch (e) {
         throw rawError
           ? e

--- a/test/action_with_inner_promise.ts
+++ b/test/action_with_inner_promise.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai'
 class MyModule extends VuexModule {
   @Action
   public value() {
-    return 'Test2'
+    return 'Test1'
   }
 
   @Action
@@ -26,7 +26,7 @@ const store = new Vuex.Store({
 describe('actions return inner promises', () => {
   it('should return resolved value', async function() {
     const value = await store.dispatch('value')
-    expect(value).to.equal('Test2')
+    expect(value).to.equal('Test1')
   })
 
   it('should return resolved promise', async function() {

--- a/test/action_with_inner_promise.ts
+++ b/test/action_with_inner_promise.ts
@@ -1,11 +1,13 @@
 import Vuex from 'vuex'
 import Vue from 'vue'
 Vue.use(Vuex)
-import { Action, Module, VuexModule } from '..'
+import { Action, Module, MutationAction, VuexModule } from '..'
 import { expect } from 'chai'
 
 @Module
 class MyModule extends VuexModule {
+  foo = ''
+
   @Action
   public value() {
     return 'Test1'
@@ -14,6 +16,11 @@ class MyModule extends VuexModule {
   @Action
   public promise() {
     return Promise.resolve('Test2')
+  }
+
+  @MutationAction({ mutate: ['foo'], rawError: true })
+  public promise2(payload: string) {
+    return Promise.resolve({ foo: payload })
   }
 }
 
@@ -32,5 +39,17 @@ describe('actions return inner promises', () => {
   it('should return resolved promise', async function() {
     const value = await store.dispatch('promise')
     expect(value).to.equal('Test2')
+  })
+
+  it('should not return resolved promise on a MutationAction', async function() {
+    // Purposefully not returning value from the action on a MutationAction because it is
+    // designed to mutate the state and you should access the value off the state
+    const {
+      state: { mm }
+    } = store
+    let value = 'Test3'
+    const resp = await store.dispatch('promise2', value)
+    expect(resp).to.equal(void 0)
+    expect(mm.foo).to.equal(value)
   })
 })

--- a/test/action_with_inner_promise.ts
+++ b/test/action_with_inner_promise.ts
@@ -1,0 +1,36 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { Action, Module, VuexModule } from '..'
+import { expect } from 'chai'
+
+@Module
+class MyModule extends VuexModule {
+  @Action
+  public value() {
+    return 'Test2'
+  }
+
+  @Action
+  public promise() {
+    return Promise.resolve('Test2')
+  }
+}
+
+const store = new Vuex.Store({
+  modules: {
+    mm: MyModule
+  }
+})
+
+describe('actions return inner promises', () => {
+  it('should return resolved value', async function() {
+    const value = await store.dispatch('value')
+    expect(value).to.equal('Test2')
+  })
+
+  it('should return resolved promise', async function() {
+    const value = await store.dispatch('promise')
+    expect(value).to.equal('Test2')
+  })
+})


### PR DESCRIPTION
I've fixed it so that @Actions will return, but @MutationAction will not return as I figure that a MutationAction is designed to mutate the state and you should then access the value off the state not from the returned value from the action. I have also added a test of my own to test the MutationAction