### PR TITLE
In an Action this['stateProp'] should always be the same as what is actually on the state

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,6 @@
 import { Action as Act, ActionContext, Module as Mod, Payload } from 'vuex'
 import { getModule, VuexModule } from './vuexmodule'
+import { addPropertiesToObject } from './helpers'
 
 /**
  * Parameters that can be passed to the @Action decorator
@@ -23,17 +24,13 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
       try {
         let actionPayload = null
 
-        /**
-         * Inside the @Action functions `this` points to `state` / `moduleAccessor`
-         * So temporarily attach `context` into `state` (or `moduleAccessor`)
-         * that allows us to access this.context
-         */
         if ((module as any)._genStatic) {
           const moduleAccessor = getModule(module as typeof VuexModule)
           moduleAccessor.context = context
           actionPayload = await actionFunction.call(moduleAccessor, payload)
         } else {
-          const thisObj = { context, ...(context.state as any) }
+          const thisObj = { context }
+          addPropertiesToObject(thisObj, context.state)
           actionPayload = await actionFunction.call(thisObj, payload)
         }
         if (commit) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Takes the properties on object from paramerter y and adds them to the object
+ * parameter x
+ * @param {object} x  Object to have properties copied onto from y
+ * @param {object} y  Object with properties to be copied to x
+ */
+export function addPropertiesToObject(x: any, y: any) {
+  for (let k of Object.keys(y || {})) {
+    Object.defineProperty(x, k, {
+      get: () => y[k]
+    })
+  }
+}

--- a/test/action_access_state.ts
+++ b/test/action_access_state.ts
@@ -10,6 +10,14 @@ class MyModule extends VuexModule {
   fieldBar = 'bar'
 
   @Mutation
+  resetFoo(data: string) {
+    this.fieldFoo = 'foo'
+  }
+  @Mutation
+  resetBar(data: string) {
+    this.fieldBar = 'bar'
+  }
+  @Mutation
   setFoo(data: string) {
     this.fieldFoo += data
   }
@@ -33,6 +41,12 @@ class MyModule extends VuexModule {
     } else {
       this.setBar(newstr)
     }
+  }
+  @Action({ rawError: true })
+  async testStateInAction(payload) {
+    this.context.commit('setFoo', payload)
+    expect((this.context.state as any).fieldFoo).to.equal('foo' + payload)
+    expect(this.fieldFoo).to.equal('foo' + payload)
   }
 
   @Action({ rawError: true })
@@ -70,5 +84,14 @@ describe('@Action with non-dynamic module', () => {
     } catch (e) {
       expect(e.message).to.equal('Foo Bar!')
     }
+  })
+  it('should have access to the state even if the state changes', async function() {
+    const {
+      state: { mm }
+    } = store
+    store.commit('resetFoo')
+    expect(mm.fieldFoo).to.equal('foo')
+    await store.dispatch('testStateInAction', 'bar')
+    expect(mm.fieldFoo).to.equal('foobar')
   })
 })

--- a/test/getters.ts
+++ b/test/getters.ts
@@ -18,9 +18,6 @@ class MyModule extends VuexModule {
     const context = this.context
     this.context.commit('incrWheels', payload)
     const axles = this.context.getters.axles
-    // Notice that the getter just changed the action's this.context and then
-    // deleted it. Because this is actually state and context was added on to state by
-    // the action and then we did a get which then changed the context and then deleted it
     expect(this.context).to.equal(context)
   }
 

--- a/test/muation_and_action.ts
+++ b/test/muation_and_action.ts
@@ -27,11 +27,6 @@ class MyModule extends VuexModule {
   async incrCountAction(payload) {
     const context = this.context
     await this.context.dispatch('getCountDelta')
-
-    // Notice that the action we just called just deleted this action's this.context.
-    // Because `this` is actually the vuex state and `context` was added on to `state` by
-    // the action and then we called another action which then added the context and then deleted it
-    // and now at this point this.context no longer exists
     expect(this.context).to.equal(context)
   }
 }


### PR DESCRIPTION
I've fixed it so that @Actions will return, but @MutationAction will not return as I figure that a MutationAction is designed to mutate the state and you should then access the value off the state not from the returned value from the action. I have also added a test of my own to test the MutationAction