### PR TITLE
respect 'namespaced' static class property

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -17,11 +17,12 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     if (!module.state) {
       module.state = moduleOptions && moduleOptions.stateFactory ? stateFactory : stateFactory()
     }
-
     if (!module.getters) {
       module.getters = {} as GetterTree<S, any>
     }
-    module.namespaced = moduleOptions && moduleOptions.namespaced
+    if (!module.namespaced) {
+      module.namespaced = moduleOptions && moduleOptions.namespaced
+    }
     Object.getOwnPropertyNames(module.prototype).forEach((funcName: string) => {
       const descriptor = Object.getOwnPropertyDescriptor(
         module.prototype,

--- a/test/static_options.ts
+++ b/test/static_options.ts
@@ -1,0 +1,36 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { Action, Module, Mutation, MutationAction, VuexModule } from '..'
+import { expect } from 'chai'
+
+interface MyModule {
+  count: number
+}
+
+@Module
+class MyModule extends VuexModule {
+  static namespaced = true
+
+  static state () {
+    return { count: 0 }
+  }
+
+  @Mutation
+  incrCount(delta: number) {
+    this.count += delta
+  }
+}
+
+const store = new Vuex.Store({
+  modules: {
+    mm: MyModule
+  }
+})
+
+describe('static module properties work', () => {
+  it('should update count', function() {
+    store.commit('mm/incrCount', 5)
+    expect(parseInt(store.state.mm.count)).to.equal(5)
+  })
+})


### PR DESCRIPTION
`extend Class` syntax is supposed to accept static properties:

https://github.com/championswimmer/vuex-module-decorators/blob/615cfd81cd486217adfcbf41d27532a026e35a84/src/vuexmodule.ts#L14

it works for e.g. `static state()` but `namespaced` flag is always overwritten with module options.

The PR fixes that, and adds regression test for static properties.

---

For now the test only includes namespaced and store; I didn't add static getters, actions and mutations as currently they require explicit type casts. I am wondering why it's `<any>` here and not `<S>`? https://github.com/championswimmer/vuex-module-decorators/blob/615cfd81cd486217adfcbf41d27532a026e35a84/src/vuexmodule.ts#L18