### PR TITLE
tests: remove unused module name options

### DIFF
--- a/src/vuexmodule.ts
+++ b/src/vuexmodule.ts
@@ -54,7 +54,7 @@ export function getModule<M extends VuexModule>(
   if (!genStatic) {
     throw new Error(`ERR_GET_MODULE_NO_STATICS : Could not get module accessor. 
       Make sure your module has name, we can't make accessors for unnamed modules
-      i.e. @Module({ 'something' })`)
+      i.e. @Module({ name: 'something' })`)
   }
   return ((moduleClass as any)._statics = genStatic(store))
 }

--- a/test/action_access_module_dynamic.ts
+++ b/test/action_access_module_dynamic.ts
@@ -7,7 +7,7 @@ import {getModule} from '../src/vuexmodule'
 
 const store = new Vuex.Store({})
 
-@Module({name: 'mm', dynamic: true, store})
+@Module({ dynamic: true, store, name: 'mm' })
 class MyModule extends VuexModule {
   fieldFoo = 'foo'
   fieldBar = 'bar'

--- a/test/dynamic_module.ts
+++ b/test/dynamic_module.ts
@@ -9,7 +9,7 @@ interface StoreType {
 }
 const store = new Vuex.Store<StoreType>({})
 
-@Module({ dynamic: true, store: store, name: 'mm' })
+@Module({ dynamic: true, store, name: 'mm' })
 class MyModule extends VuexModule {
   count = 0
 

--- a/test/getmodule/getmodule_dynamic.ts
+++ b/test/getmodule/getmodule_dynamic.ts
@@ -9,7 +9,7 @@ interface StoreType {
 }
 const store = new Vuex.Store<StoreType>({})
 
-@Module({ dynamic: true, store: store, name: 'mm' })
+@Module({ dynamic: true, store, name: 'mm' })
 class MyModule extends VuexModule {
   count = 0
 

--- a/test/getmodule/getmodule_dynamic_namespaced.ts
+++ b/test/getmodule/getmodule_dynamic_namespaced.ts
@@ -9,7 +9,7 @@ interface StoreType {
 }
 const store = new Vuex.Store<StoreType>({})
 
-@Module({ dynamic: true, store: store, name: 'mm', namespaced: true })
+@Module({ dynamic: true, store, name: 'mm', namespaced: true })
 class MyModule extends VuexModule {
   count = 0
 

--- a/test/getmodule/getmodule_nondynamic_withname.ts
+++ b/test/getmodule/getmodule_nondynamic_withname.ts
@@ -8,7 +8,7 @@ interface StoreType {
   mm: MyModule
 }
 
-@Module({ name: 'mm' })
+@Module
 class MyModule extends VuexModule {
   count = 0
 

--- a/test/namespaced_getters.ts
+++ b/test/namespaced_getters.ts
@@ -4,7 +4,7 @@ Vue.use(Vuex)
 import { Action, Module, Mutation, MutationAction, VuexModule } from '..'
 import { expect } from 'chai'
 
-@Module({ namespaced: true, name: 'mm' })
+@Module({ namespaced: true })
 class MyModule extends VuexModule {
   wheels = 2
 

--- a/test/namespaced_mutation.ts
+++ b/test/namespaced_mutation.ts
@@ -4,7 +4,7 @@ Vue.use(Vuex)
 import { Action, Module, Mutation, MutationAction, VuexModule } from '..'
 import { expect } from 'chai'
 
-@Module({ namespaced: true, name: 'mm' })
+@Module({ namespaced: true })
 class MyModule extends VuexModule {
   count = 0
 


### PR DESCRIPTION
Test cases use `name: 'mm'` where it's not needed. Moreover, it's misleading:

```ts
@Module({ name: 'mm' })
class MyModule extends VuexModule { /*...*/ }

const store = new Vuex.Store({
  modules: {
    bummer: MyModule
  }
})

/// ...

store.commit('mm/incrWheels', 4) // Error: unknown mutation
```

The PR removes unused name options, unifies formatting, and fixes a typo in the error messge.
