### PR TITLE
Update statics' store reference with each getModule() call

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -47,8 +47,9 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     if (modOpt.name) {
       Object.defineProperty(constructor, '_genStatic', {
         value: (store?: Store<any>) => {
-          let statics = {}
+          let statics = {} as any
           modOpt.store = modOpt.store || store
+          statics.store = modOpt.store
           if (!modOpt.store) {
             throw new Error(`ERR_STORE_NOT_PROVIDED: To use getModule(), either the module
             should be decorated with store in decorator, i.e. @Module({store: store}) or

--- a/src/module/staticGenerators.ts
+++ b/src/module/staticGenerators.ts
@@ -12,7 +12,7 @@ export function staticStateGenerator<S>(
       if (['undefined', 'function'].indexOf(typeof (module.state as any)[key]) === -1) {
         Object.defineProperty(statics, key, {
           get() {
-            return modOpt.store.state[modOpt.name][key]
+            return statics.store.state[modOpt.name][key]
           }
         })
       }
@@ -29,13 +29,13 @@ export function staticGetterGenerator<S>(
     if (module.namespaced) {
       Object.defineProperty(statics, key, {
         get() {
-          return modOpt.store.getters[`${modOpt.name}/${key}`]
+          return statics.store.getters[`${modOpt.name}/${key}`]
         }
       })
     } else {
       Object.defineProperty(statics, key, {
         get() {
-          return modOpt.store.getters[key]
+          return statics.store.getters[key]
         }
       })
     }
@@ -50,11 +50,11 @@ export function staticMutationGenerator<S>(
   Object.keys(module.mutations as MutationTree<S>).forEach((key) => {
     if (module.namespaced) {
       statics[key] = function(...args: any[]) {
-        modOpt.store.commit(`${modOpt.name}/${key}`, ...args)
+        statics.store.commit(`${modOpt.name}/${key}`, ...args)
       }
     } else {
       statics[key] = function(...args: any[]) {
-        modOpt.store.commit(key, ...args)
+        statics.store.commit(key, ...args)
       }
     }
   })
@@ -68,11 +68,11 @@ export function staticActionGenerators<S>(
   Object.keys(module.actions as ActionTree<S, any>).forEach((key) => {
     if (module.namespaced) {
       statics[key] = async function(...args: any[]) {
-        return modOpt.store.dispatch(`${modOpt.name}/${key}`, ...args)
+        return statics.store.dispatch(`${modOpt.name}/${key}`, ...args)
       }
     } else {
       statics[key] = async function(...args: any[]) {
-        return modOpt.store.dispatch(key, ...args)
+        return statics.store.dispatch(key, ...args)
       }
     }
   })

--- a/src/vuexmodule.ts
+++ b/src/vuexmodule.ts
@@ -47,7 +47,9 @@ export function getModule<M extends VuexModule>(
   store?: Store<any>
 ): M {
   if ((moduleClass as any)._statics) {
-    return (moduleClass as any)._statics
+    const _statics = (moduleClass as any)._statics
+    _statics.store = store || _statics.store
+    return _statics
   }
   const genStatic: (providedStore?: Store<any>) => M = (moduleClass as any)._genStatic
   if (!genStatic) {


### PR DESCRIPTION
If we refer the store from static.store, or somewhere accessible in getModule(), the generated _genStatic can be updated with any changes in store reference.

Why is store reference even changed ?
In Nuxt.js, all the modules are generated using getModule() using the store provided via nuxt plugin's context. This sets the internal modOpt.store reference.

Later on, In fetch() of the page components, the store provided is entirely different of the one provided in plugins (Nuxt bug?). This is observed only server side. Everything works smooth in client side