### PR TITLE
Accessor for states with stateFactory: true

### DIFF
--- a/src/module/staticGenerators.ts
+++ b/src/module/staticGenerators.ts
@@ -6,10 +6,11 @@ export function staticStateGenerator<S>(
   modOpt: DynamicModuleOptions,
   statics: any
 ) {
-  Object.keys(module.state as S).forEach((key) => {
-    if ((module.state as S).hasOwnProperty(key)) {
+  const state: S = modOpt.stateFactory ? (module as any).state() : module.state
+  Object.keys(state).forEach((key) => {
+    if (state.hasOwnProperty(key)) {
       // If not undefined or function means it is a state value
-      if (['undefined', 'function'].indexOf(typeof (module.state as any)[key]) === -1) {
+      if (['undefined', 'function'].indexOf(typeof (state as any)[key]) === -1) {
         Object.defineProperty(statics, key, {
           get() {
             return modOpt.store.state[modOpt.name][key]


### PR DESCRIPTION
Previously, module.state wasnt present for modules with modOpt.stateFactory: true

Is this feature disabled intentionally ?