### PR TITLE
Reject promise if error is thrown on MutationAction

### DIFF
--- a/src/mutationaction.ts
+++ b/src/mutationaction.ts
@@ -33,6 +33,7 @@ function mutationActionDecoratorFactory<T>(params: MutationActionParams<T>) {
         } else {
           console.error('Could not perform action ' + key.toString())
           console.error(e)
+          return Promise.reject(e)
         }
       }
     }


### PR DESCRIPTION
Fixes #122 
This makes MutationAction behave in the same way as Action