### PR TITLE
Added "preserveState" option for dynamic modules

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -82,7 +82,10 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
       }
       modOpt.store.registerModule(
         modOpt.name, // TODO: Handle nested modules too in future
-        module
+        module,
+        {
+          preserveState: modOpt.preserveState
+        }
       )
     }
     return constructor

--- a/src/moduleoptions.ts
+++ b/src/moduleoptions.ts
@@ -41,6 +41,11 @@ export interface DynamicModuleOptions {
    * Whether to generate a plain state object, or a state factory for the module
    */
   stateFactory?: boolean
+
+  /**
+   * Whether to preserve the previous state
+   */
+  preserveState?: boolean
 }
 
 export type ModuleOptions = StaticModuleOptions | DynamicModuleOptions

--- a/test/preserve_state_in_dynamic_module.ts
+++ b/test/preserve_state_in_dynamic_module.ts
@@ -1,0 +1,29 @@
+import Vuex, { Module as Mod, ModuleTree } from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { Action, Module, Mutation, MutationAction, VuexModule } from '..'
+import { expect } from 'chai'
+
+interface StoreType {
+  mm: MyModule
+}
+const store = new Vuex.Store<StoreType>({
+  modules: {
+    mm: {
+      state: {
+        count: 5
+      }
+    }
+  } as ModuleTree<any>
+})
+
+@Module({ dynamic: true, store, name: 'mm', preserveState: true })
+class MyModule extends VuexModule {
+  count = 0
+}
+
+describe('dynamic module with preserve data', () => {
+  it('should preserve count to 5', function() {
+    expect(store.state.mm.count).to.equal(5)
+  })
+})


### PR DESCRIPTION
I added the "preserveState" option for dynamic modules, as described in Vuex documentation
`https://vuex.vuejs.org/guide/modules.html#preserving-state`

It is very important for me, since I use a custom module which loads my data from a local DB.