### PR TITLE
Hotfix/ssr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,3 +317,57 @@ someMethod() {
   return exampleStore.exampleGetter
 }
 ```
+
+### Using the decorators with ServerSideRender
+
+When SSR is involved the store is recreated on each request. Every time the module is accessed
+using `getModule` function the current store instance must be provided and the module must
+be manually registered to the root store modules
+
+#### Example
+
+```typescript
+// store/modules/MyStoreModule.ts
+import { Module, VuexModule, Mutation } from 'vuex-module-decorators'
+
+@Module({
+  name: 'MyStoreModule',
+  namespaced: true,
+  stateFactory: true,
+})
+export default class MyStoreModule extends VuexModule {
+  public test: string = 'initial'
+
+  @Mutation
+  public setTest(val: string) {
+    this.test = val
+  }
+}
+
+
+// store/index.ts
+import Vuex from 'vuex'
+import MyStoreModule from '~/store/modules/MyStoreModule'
+
+export function createStore() {
+  return new Vuex.Store({
+    modules: {
+      MyStoreModule,
+    },
+  }
+}
+
+// components/Random.tsx
+import { Component, Vue } from 'vue-property-decorator';
+import { getModule } from 'vuex-module-decorators';
+import MyStoreModule from '~/store/modules/MyStoreModule'
+
+@Component
+export default class extends Vue {
+    public created() {
+        const MyModuleInstance = getModule(MyStoreModule, this.$store);
+        // Do stuff with module
+        MyModuleInstance.setTest('random')
+    }
+}
+```

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,6 @@
 import { Action as Act, ActionContext, Module as Mod, Payload } from 'vuex'
 import { getModule, VuexModule } from './vuexmodule'
-import { addPropertiesToObject } from './helpers'
+import { addPropertiesToObject, getModuleName } from './helpers'
 
 /**
  * Parameters that can be passed to the @Action decorator
@@ -25,7 +25,10 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
         let actionPayload = null
 
         if ((module as any)._genStatic) {
-          const moduleAccessor = getModule(module as typeof VuexModule)
+          const moduleName = getModuleName(module)
+          const moduleAccessor = context.rootGetters[moduleName]
+            ? context.rootGetters[moduleName]
+            : getModule(module as typeof VuexModule)
           moduleAccessor.context = context
           actionPayload = await actionFunction.call(moduleAccessor, payload)
         } else {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,3 +11,16 @@ export function addPropertiesToObject(target: any, source: any) {
     })
   }
 }
+
+/**
+ * Returns a namespaced name of the module to be used as a store getter
+ * @param module
+ */
+export function getModuleName(module: any): string {
+  if (!module._vmdModuleName) {
+    throw new Error(`ERR_GET_MODULE_NAME : Could not get module accessor.
+      Make sure your module has name, we can't make accessors for unnamed modules
+      i.e. @Module({ name: 'something' })`)
+  }
+  return `vuexModuleDecorators/${module._vmdModuleName}`
+}

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -9,6 +9,21 @@ import {
   staticStateGenerator
 } from './staticGenerators'
 
+function registerDynamicModule<S>(module: Mod<S, any>, modOpt: DynamicModuleOptions) {
+  if (!modOpt.name) {
+    throw new Error('Name of module not provided in decorator options')
+  }
+
+  if (!modOpt.store) {
+    throw new Error('Store not provided in decorator options when using dynamic option')
+  }
+
+  modOpt.store.registerModule(
+    modOpt.name, // TODO: Handle nested modules too in future
+    module
+  )
+}
+
 function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
   return function<TFunction extends Function>(constructor: TFunction): TFunction | void {
     const module: Function & Mod<S, any> = constructor
@@ -75,18 +90,7 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     }
 
     if (modOpt.dynamic) {
-      if (!modOpt.name) {
-        throw new Error('Name of module not provided in decorator options')
-      }
-
-      if (!modOpt.store) {
-        throw new Error('Store not provided in decorator options when using dynamic option')
-      }
-
-      modOpt.store.registerModule(
-        modOpt.name, // TODO: Handle nested modules too in future
-        module
-      )
+      registerDynamicModule(module, modOpt)
     }
     return constructor
   }

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -47,13 +47,7 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     if (modOpt.name) {
       Object.defineProperty(constructor, '_genStatic', {
         value: (store?: Store<any>) => {
-          let statics = {}
-          modOpt.store = modOpt.store || store
-          if (!modOpt.store) {
-            throw new Error(`ERR_STORE_NOT_PROVIDED: To use getModule(), either the module
-            should be decorated with store in decorator, i.e. @Module({store: store}) or
-            store should be passed when calling getModule(), i.e. getModule(MyModule, this.$store)`)
-          }
+          let statics = { store: store || modOpt.store }
           // ===========  For statics ==============
           // ------ state -------
           staticStateGenerator(module, modOpt, statics)
@@ -73,6 +67,10 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
           }
           return statics
         }
+      })
+
+      Object.defineProperty(constructor, '_vmdModuleName', {
+        value: modOpt.name
       })
     }
 

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -63,6 +63,11 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
       Object.defineProperty(constructor, '_genStatic', {
         value: (store?: Store<any>) => {
           let statics = { store: store || modOpt.store }
+          if (!statics.store) {
+            throw new Error(`ERR_STORE_NOT_PROVIDED: To use getModule(), either the module
+            should be decorated with store in decorator, i.e. @Module({store: store}) or
+            store should be passed when calling getModule(), i.e. getModule(MyModule, this.$store)`)
+          }
           // ===========  For statics ==============
           // ------ state -------
           staticStateGenerator(module, modOpt, statics)

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -80,6 +80,11 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
       if (!modOpt.name) {
         throw new Error('Name of module not provided in decorator options')
       }
+
+      if (!modOpt.store) {
+        throw new Error('Store not provided in decorator options when using dynamic option')
+      }
+
       modOpt.store.registerModule(
         modOpt.name, // TODO: Handle nested modules too in future
         module

--- a/src/module/staticGenerators.ts
+++ b/src/module/staticGenerators.ts
@@ -13,7 +13,7 @@ export function staticStateGenerator<S>(
       if (['undefined', 'function'].indexOf(typeof (state as any)[key]) === -1) {
         Object.defineProperty(statics, key, {
           get() {
-            return modOpt.store.state[modOpt.name][key]
+            return statics.store.state[modOpt.name][key]
           }
         })
       }
@@ -30,13 +30,13 @@ export function staticGetterGenerator<S>(
     if (module.namespaced) {
       Object.defineProperty(statics, key, {
         get() {
-          return modOpt.store.getters[`${modOpt.name}/${key}`]
+          return statics.store.getters[`${modOpt.name}/${key}`]
         }
       })
     } else {
       Object.defineProperty(statics, key, {
         get() {
-          return modOpt.store.getters[key]
+          return statics.store.getters[key]
         }
       })
     }
@@ -51,11 +51,11 @@ export function staticMutationGenerator<S>(
   Object.keys(module.mutations as MutationTree<S>).forEach((key) => {
     if (module.namespaced) {
       statics[key] = function(...args: any[]) {
-        modOpt.store.commit(`${modOpt.name}/${key}`, ...args)
+        statics.store.commit(`${modOpt.name}/${key}`, ...args)
       }
     } else {
       statics[key] = function(...args: any[]) {
-        modOpt.store.commit(key, ...args)
+        statics.store.commit(key, ...args)
       }
     }
   })
@@ -69,11 +69,11 @@ export function staticActionGenerators<S>(
   Object.keys(module.actions as ActionTree<S, any>).forEach((key) => {
     if (module.namespaced) {
       statics[key] = async function(...args: any[]) {
-        return modOpt.store.dispatch(`${modOpt.name}/${key}`, ...args)
+        return statics.store.dispatch(`${modOpt.name}/${key}`, ...args)
       }
     } else {
       statics[key] = async function(...args: any[]) {
-        return modOpt.store.dispatch(key, ...args)
+        return statics.store.dispatch(key, ...args)
       }
     }
   })

--- a/src/vuexmodule.ts
+++ b/src/vuexmodule.ts
@@ -7,6 +7,7 @@ import {
   Store,
   ActionContext
 } from 'vuex'
+import { getModuleName } from './helpers'
 
 export class VuexModule<S = ThisType<any>, R = any> implements Mod<S, R> {
   /*
@@ -46,14 +47,27 @@ export function getModule<M extends VuexModule>(
   moduleClass: ConstructorOf<M>,
   store?: Store<any>
 ): M {
-  if ((moduleClass as any)._statics) {
+  const moduleName = getModuleName(moduleClass)
+  if (store && store.getters[moduleName]) {
+    return store.getters[moduleName]
+  } else if ((moduleClass as any)._statics) {
     return (moduleClass as any)._statics
   }
+
   const genStatic: (providedStore?: Store<any>) => M = (moduleClass as any)._genStatic
   if (!genStatic) {
     throw new Error(`ERR_GET_MODULE_NO_STATICS : Could not get module accessor.
       Make sure your module has name, we can't make accessors for unnamed modules
       i.e. @Module({ name: 'something' })`)
   }
-  return ((moduleClass as any)._statics = genStatic(store))
+
+  const storeModule = genStatic(store)
+
+  if (store) {
+    store.getters[moduleName] = storeModule
+  } else {
+    ;(moduleClass as any)._statics = storeModule
+  }
+
+  return storeModule
 }

--- a/test/dynamic_module.ts
+++ b/test/dynamic_module.ts
@@ -25,3 +25,26 @@ describe('mutation works on dynamic module', () => {
     expect(store.state.mm.count).to.equal(5)
   })
 })
+
+describe('dynamic module', () => {
+  it('should error without store in decorator', function() {
+    expect(() => {
+      @Module({ name: 'mm', dynamic: true })
+      class MyModule extends VuexModule {}
+    }).to.throw('Store not provided in decorator options when using dynamic option')
+  })
+
+  it('should error without name in decorator', function() {
+    expect(() => {
+      const store = new Vuex.Store({})
+
+      // Ignore the TS error when module options are missing required name property
+      // @ts-ignore
+      @Module({
+        store,
+        dynamic: true
+      })
+      class MyDynamicModule extends VuexModule {}
+    }).to.throw('Name of module not provided in decorator options')
+  })
+})

--- a/test/getmodule_action_mutation.ts
+++ b/test/getmodule_action_mutation.ts
@@ -1,0 +1,73 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, Action, Mutation, VuexModule } from '..'
+import { expect } from 'chai'
+
+const store = new Vuex.Store({})
+
+const defaultValue = 10
+
+@Module({ name: 'mm', store, dynamic: true })
+class MyModule extends VuexModule {
+  public value = defaultValue
+
+  @Mutation
+  public setValue(value: number): void {
+    this.value = value
+  }
+
+  @Action({ commit: 'setValue' })
+  public async resetValue(): Promise<number> {
+    return defaultValue
+  }
+}
+
+@Module({ name: 'mnm', store, dynamic: true, namespaced: true })
+class MyNamespacedModule extends VuexModule {
+  public value = defaultValue
+
+  @Mutation
+  public setValue(value: number): void {
+    this.value = value
+  }
+
+  @Action({ commit: 'setValue' })
+  public async resetValue(): Promise<number> {
+    return defaultValue
+  }
+}
+
+describe('actions and mutations on getModule()', () => {
+  it('mutation should set provided value', function() {
+    const module = getModule(MyModule)
+    expect(module.value).to.equal(defaultValue)
+
+    const newValue = defaultValue + 2
+    module.setValue(newValue)
+    expect(module.value).to.equal(newValue)
+  })
+
+  it('action should reset value to default', function() {
+    const module = getModule(MyModule)
+    return module.resetValue().then(() => {
+      expect(module.value).to.equal(defaultValue)
+    })
+  })
+
+  it('mutation should set provided value on namespaced module', function() {
+    const module = getModule(MyNamespacedModule)
+    expect(module.value).to.equal(defaultValue)
+
+    const newValue = defaultValue + 2
+    module.setValue(newValue)
+    expect(module.value).to.equal(newValue)
+  })
+
+  it('action should reset value to default on namespaced module', function() {
+    const module = getModule(MyNamespacedModule)
+    return module.resetValue().then(() => {
+      expect(module.value).to.equal(defaultValue)
+    })
+  })
+})

--- a/test/getmodule_generated_on_store.ts
+++ b/test/getmodule_generated_on_store.ts
@@ -1,0 +1,45 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, Mutation, VuexModule } from '..'
+import { expect } from 'chai'
+import { getModuleName } from '../src/helpers';
+
+interface StoreType {
+  mm: MyModule
+}
+
+@Module({ name: 'mm', stateFactory: true })
+class MyModule extends VuexModule {
+  count = 0
+
+  @Mutation
+  public incrCount() {
+    ++this.count
+  }
+}
+
+const store = new Vuex.Store<StoreType>({
+  modules: {
+    mm: MyModule
+  }
+})
+
+describe('module  generated on a single store', () => {
+  it('should generate module in store getters', function() {
+    const module = getModule(MyModule, store)
+    expect(store.getters[getModuleName(MyModule)]).to.equal(module)
+  })
+
+  it('should retain state between getModule calls', function() {
+    const module = getModule(MyModule, store)
+    module.incrCount()
+    expect(module.count).to.equal(1)
+
+    const secondModule = getModule(MyModule, store)
+    expect(secondModule.count).to.equal(1)
+
+    secondModule.incrCount()
+    expect(module.count).to.equal(2)
+  })
+})

--- a/test/getmodule_generated_on_two_stores.ts
+++ b/test/getmodule_generated_on_two_stores.ts
@@ -1,0 +1,46 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, Mutation, VuexModule } from '..'
+import { expect } from 'chai'
+
+interface StoreType {
+  mm: MyModule
+}
+
+@Module({ name: 'mm', stateFactory: true })
+class MyModule extends VuexModule {
+  count = 0
+
+  @Mutation
+  public incrCount() {
+    ++this.count
+  }
+}
+
+const firstStore = new Vuex.Store<StoreType>({
+  modules: {
+    mm: MyModule
+  }
+})
+
+const secondStore = new Vuex.Store<StoreType>({
+  modules: {
+    mm: MyModule
+  }
+})
+
+describe('modules generated on two different stores', () => {
+  it('should each have their own state', function() {
+    const module = getModule(MyModule, firstStore)
+    const secondModule = getModule(MyModule, secondStore)
+
+    module.incrCount()
+    expect(module.count).to.equal(1)
+    expect(secondModule.count).to.equal(0)
+
+    secondModule.incrCount()
+    expect(module.count).to.equal(1)
+    expect(secondModule.count).to.equal(1)
+  })
+})

--- a/test/getmodule_getter.ts
+++ b/test/getmodule_getter.ts
@@ -1,0 +1,37 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, Action, Mutation, VuexModule } from '..'
+import { expect } from 'chai'
+
+const store = new Vuex.Store({})
+
+@Module({ name: 'mm', store, dynamic: true })
+class MyModule extends VuexModule {
+  public value = 10
+
+  public get twofold(): number {
+    return this.value * 2
+  }
+}
+
+@Module({ name: 'mnm', store, dynamic: true, namespaced: true })
+class MyNamespacedModule extends VuexModule {
+  public value = 10
+
+  public get twofold(): number {
+    return this.value * 2
+  }
+}
+
+describe('using getters on getModule()', () => {
+  it('getter should return adjusted value', function() {
+    expect(getModule(MyModule).value).to.equal(10)
+    expect(getModule(MyModule).twofold).to.equal(20)
+  })
+
+  it('getter should return adjusted value on namespaced module', function() {
+    expect(getModule(MyNamespacedModule).value).to.equal(10)
+    expect(getModule(MyNamespacedModule).twofold).to.equal(20)
+  })
+})

--- a/test/getmodule_noname.ts
+++ b/test/getmodule_noname.ts
@@ -4,10 +4,6 @@ Vue.use(Vuex)
 import { getModule, Module, VuexModule } from '..'
 import { expect } from 'chai'
 
-interface StoreType {
-  mm: MyModule
-}
-
 @Module
 class MyModule extends VuexModule {}
 

--- a/test/getmodule_noname.ts
+++ b/test/getmodule_noname.ts
@@ -1,0 +1,18 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, VuexModule } from '..'
+import { expect } from 'chai'
+
+interface StoreType {
+  mm: MyModule
+}
+
+@Module
+class MyModule extends VuexModule {}
+
+describe('getModule() on unnamed module', () => {
+  it('should error without name in decorator', function() {
+    expect(() => getModule(MyModule)).to.throw(/ERR_GET_MODULE_NAME .*/)
+  })
+})

--- a/test/getmodule_statics.ts
+++ b/test/getmodule_statics.ts
@@ -1,0 +1,15 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { getModule, Module, VuexModule } from '..'
+import { expect } from 'chai'
+
+@Module({ name: 'mm' })
+class MyModule extends VuexModule {}
+
+describe('getModule() without providing store', () => {
+  it('should generate the module on statics property', function() {
+    const module = getModule(MyModule)
+    expect((MyModule as any)._statics).to.equal(module)
+  })
+})

--- a/test/getmodule_without_store.ts
+++ b/test/getmodule_without_store.ts
@@ -4,12 +4,21 @@ Vue.use(Vuex)
 import { getModule, Module, VuexModule } from '..'
 import { expect } from 'chai'
 
-@Module({ name: 'mm' })
+const store = new Vuex.Store({})
+
+@Module({ name: 'mm', store })
 class MyModule extends VuexModule {}
+
+@Module({ name: 'mmws' })
+class MyModuleWithoutStore extends VuexModule {}
 
 describe('getModule() without providing store', () => {
   it('should generate the module on statics property', function() {
     const module = getModule(MyModule)
     expect((MyModule as any)._statics).to.equal(module)
+  })
+
+  it('should error without defining store on the module', function() {
+    expect(() => getModule(MyModuleWithoutStore)).to.throw(/ERR_STORE_NOT_PROVIDED.*/)
   })
 })

--- a/test/reserved_keys_as_properties.ts
+++ b/test/reserved_keys_as_properties.ts
@@ -1,0 +1,16 @@
+import Vuex, { Module as Mod } from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { Action, Module, Mutation, MutationAction, VuexModule } from '..'
+import { expect } from 'chai'
+
+describe('prevent using reserved keys', () => {
+  it('as module properties', function() {
+    expect(() => {
+      @Module
+      class MyModule extends VuexModule {
+        actions: any = null
+      }
+    }).to.throw(/ERR_RESERVED_STATE_KEY_USED: .*/)
+  })
+})


### PR DESCRIPTION
SSR breaks the modules by always using the Module version generated from the first request that reaches the server and creates the Module... then the vuex store used during this request is also shared between all consecutive requests.

This is because the generated instance of the `@Module` class is stored in its static property `_statics` and cached for later use (later use being also later requests made to the server)

This changes the behaviour so that the store provided to `getModule()` is used to save the generated instace of the `@Module`... store being recreated in SSR on each request ensures that the module is also recreated on each request.

More info in #146 