### PR TITLE
#174 Fix actions and mutation inheritance

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -14,8 +14,8 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
   const { commit = undefined, rawError = false, root = false } = params || {}
   return function(target: Object, key: string | symbol, descriptor: TypedPropertyDescriptor<any>) {
     const module = target.constructor as Mod<T, any>
-    if (!module.actions) {
-      module.actions = {}
+    if (!module.hasOwnProperty('actions')) {
+      module.actions = Object.assign({}, module.actions)
     }
     const actionFunction: Function = descriptor.value
     const action: Act<typeof target, any> = async function(
@@ -55,7 +55,7 @@ function actionDecoratorFactory<T>(params?: ActionDecoratorParams): MethodDecora
             )
       }
     }
-    module.actions[key as string] = root ? { root, handler: action } : action
+    module.actions![key as string] = root ? { root, handler: action } : action
   }
 }
 

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -6,12 +6,12 @@ export function Mutation<T extends Object, R>(
   descriptor: TypedPropertyDescriptor<(...args: any[]) => R>
 ) {
   const module = target.constructor as Mod<T, any>
-  if (!module.mutations) {
-    module.mutations = {}
+  if (!module.hasOwnProperty('mutations')) {
+    module.mutations = Object.assign({}, module.mutations)
   }
   const mutationFunction: Function = descriptor.value ? descriptor.value : (...args: any[]) => ({})
   const mutation: Mut<typeof target> = function(state: typeof target, payload: Payload) {
     mutationFunction.call(state, payload)
   }
-  module.mutations[key as string] = mutation
+  module.mutations![key as string] = mutation
 }

--- a/src/mutationaction.ts
+++ b/src/mutationaction.ts
@@ -13,11 +13,11 @@ function mutationActionDecoratorFactory<T extends Object>(params: MutationAction
     descriptor: TypedPropertyDescriptor<(...args: any[]) => Promise<Partial<T>>>
   ) {
     const module = target.constructor as Mod<T, any>
-    if (!module.mutations) {
-      module.mutations = {}
+    if (!module.hasOwnProperty('mutations')) {
+      module.mutations = Object.assign({}, module.mutations)
     }
-    if (!module.actions) {
-      module.actions = {}
+    if (!module.hasOwnProperty('actions')) {
+      module.actions = Object.assign({}, module.actions)
     }
     const mutactFunction = descriptor.value as ((payload: any) => Promise<any>)
 
@@ -56,8 +56,8 @@ function mutationActionDecoratorFactory<T extends Object>(params: MutationAction
         }
       }
     }
-    module.actions[key as string] = params.root ? { root: true, handler: action } : action
-    module.mutations[key as string] = mutation
+    module.actions![key as string] = params.root ? { root: true, handler: action } : action
+    module.mutations![key as string] = mutation
   }
 }
 


### PR DESCRIPTION
Using `@Action` or `@Mutation` in base store class currenlty produses unexpected behavior when all stores using the same action for all inherited classes.

More info: #174 Actions inheritance