### PR TITLE
test: make it clearer that namespaced module is used

### DIFF
--- a/test/getmodule_getter.ts
+++ b/test/getmodule_getter.ts
@@ -17,10 +17,10 @@ class MyModule extends VuexModule {
 
 @Module({ name: 'mnm', store, dynamic: true, namespaced: true })
 class MyNamespacedModule extends VuexModule {
-  public value = 10
+  public value = 15
 
   public get twofold(): number {
-    return this.value * 2
+    return this.value * 3
   }
 }
 
@@ -31,7 +31,7 @@ describe('using getters on getModule()', () => {
   })
 
   it('getter should return adjusted value on namespaced module', function() {
-    expect(getModule(MyNamespacedModule).value).to.equal(10)
-    expect(getModule(MyNamespacedModule).twofold).to.equal(20)
+    expect(getModule(MyNamespacedModule).value).to.equal(15)
+    expect(getModule(MyNamespacedModule).twofold).to.equal(45)
   })
 })


### PR DESCRIPTION
I think having different values for root (value=10) and namespaced (value=15) modules, instead of setting both to value=10, helps being confident that namespaced module is used in this case (maybe it's obvious, but well, I think it's clearer this way).