### PR TITLE
fixed #203 Reusable getters

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -25,6 +25,32 @@ function registerDynamicModule<S>(module: Mod<S, any>, modOpt: DynamicModuleOpti
   )
 }
 
+function addGettersToModule<S>(
+  targetModule: Function & Mod<S, any>,
+  srcModule: Function & Mod<S, any>
+) {
+  Object.getOwnPropertyNames(srcModule.prototype).forEach((funcName: string) => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      srcModule.prototype,
+      funcName
+    ) as PropertyDescriptor
+    if (descriptor.get && targetModule.getters) {
+      targetModule.getters[funcName] = function(
+        state: S,
+        getters: GetterTree<S, any>,
+        rootState: any,
+        rootGetters: GetterTree<any, any>
+      ) {
+        const thisObj = { context: { state, getters, rootState, rootGetters } }
+        addPropertiesToObject(thisObj, state)
+        addPropertiesToObject(thisObj, getters)
+        const got = (descriptor.get as Function).call(thisObj)
+        return got
+      }
+    }
+  })
+}
+
 function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
   return function<TFunction extends Function>(constructor: TFunction): TFunction | void {
     const module: Function & Mod<S, any> = constructor
@@ -39,26 +65,7 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     if (!module.namespaced) {
       module.namespaced = moduleOptions && moduleOptions.namespaced
     }
-    Object.getOwnPropertyNames(module.prototype).forEach((funcName: string) => {
-      const descriptor = Object.getOwnPropertyDescriptor(
-        module.prototype,
-        funcName
-      ) as PropertyDescriptor
-      if (descriptor.get && module.getters) {
-        module.getters[funcName] = function(
-          state: S,
-          getters: GetterTree<S, any>,
-          rootState: any,
-          rootGetters: GetterTree<any, any>
-        ) {
-          const thisObj = { context: { state, getters, rootState, rootGetters } }
-          addPropertiesToObject(thisObj, state)
-          addPropertiesToObject(thisObj, getters)
-          const got = (descriptor.get as Function).call(thisObj)
-          return got
-        }
-      }
-    })
+    addGettersToModule(module, module)
     const modOpt = moduleOptions as DynamicModuleOptions
     if (modOpt.name) {
       Object.defineProperty(constructor, '_genStatic', {

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -65,6 +65,11 @@ function moduleDecoratorFactory<S>(moduleOptions: ModuleOptions) {
     if (!module.namespaced) {
       module.namespaced = moduleOptions && moduleOptions.namespaced
     }
+    let parentModule = Object.getPrototypeOf(module)
+    while (parentModule.name !== 'VuexModule' && parentModule.name !== '') {
+      addGettersToModule(module, parentModule)
+      parentModule = Object.getPrototypeOf(parentModule)
+    }
     addGettersToModule(module, module)
     const modOpt = moduleOptions as DynamicModuleOptions
     if (modOpt.name) {

--- a/test/getters_childmodule.ts
+++ b/test/getters_childmodule.ts
@@ -1,0 +1,66 @@
+import Vuex, { Module as Mod } from 'vuex'
+import Vue from 'vue'
+Vue.use(Vuex)
+import { Action, Module, Mutation, VuexModule } from '..'
+import { expect } from 'chai'
+
+class ParentModule extends VuexModule {
+  wheels = 2
+
+  @Mutation
+  incrWheels(extra: number) {
+    this.wheels += extra
+  }
+
+  @Action({ rawError: true })
+  async incrWheelsAction(payload: number) {
+    const context = this.context
+    this.context.commit('incrWheels', payload)
+    const axles = this.context.getters.axles
+    expect(this.context).to.equal(context)
+    expect(this.axles).to.equal(axles)
+  }
+
+  get axles() {
+    return this.wheels / 2
+  }
+  get axlesAndWheels() {
+    return { axles: this.axles, wheels: this.wheels }
+  }
+}
+
+@Module
+class ChildModule extends ParentModule {
+  get axlesAndWheels() {
+    return { axles: this.axles, axlesDouble: this.axlesDouble, wheels: this.wheels }
+  }
+
+  get axlesDouble() {
+    return this.wheels
+  }
+}
+
+
+
+const store = new Vuex.Store({
+  state: {},
+  modules: {
+    mm: ChildModule
+  }
+})
+
+describe('fetching via getters works', () => {
+
+  it('should be able to access parent getter', async () => {
+    await store.dispatch('incrWheelsAction', 2)
+    const axles = store.getters.axles
+    expect(axles).to.equal(2)
+  })
+
+  it('should be able to override axlesAndWheels', async function() {
+    await store.dispatch('incrWheelsAction', 2)
+    const axlesAndWheels = store.getters.axlesAndWheels
+    expect(axlesAndWheels.axlesDouble).to.equal(6)
+  })
+
+})


### PR DESCRIPTION
I defined ParentModule and ChildModule like below code in my app. 
But  ParentModule getters didn’t exist in store.getters.
Then I found issue #203  and fixed it.
Please check my pull request.

```typescript
class ParentModule exnteds VuexModule {
  get foo(): string {
    return 'foo'
  }
}

@Module
class ChildModule extends ParentModule {
}

const store = new Vuex.Store({
  state: {},
  modules: {
    mm: ChildModule
  }
})

store.getters.foo // foo is undefined.
```