### PR TITLE
Add message to docs about store name being reserved for use by vuex-module-decorators

### DIFF
--- a/docs/pages/core/state.md
+++ b/docs/pages/core/state.md
@@ -27,3 +27,7 @@ export default {
 :::danger 🚨 WARNING
 If state value cannot be determined, it **MUST** be initialized with `null`. Just like `wheels: number | null = null`.
 :::
+
+:::danger 🚨 WARNING
+Ensure that you do not have a getter or property in your module with the name `store`. This conflicts with `vuex-property-decorator` causing Vue "Too much recursion" errors.
+:::


### PR DESCRIPTION
Fix #322 